### PR TITLE
Fix auteurId type in subject creation

### DIFF
--- a/backend_forum/src/main/java/fr/dsfr/forum/beans/dto/SujetDTO/CreerSujetDTO.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/beans/dto/SujetDTO/CreerSujetDTO.java
@@ -5,6 +5,6 @@ import lombok.Data;
 @Data
 public class CreerSujetDTO {
     private String titre;
-    private String auteurId;
+    private Long auteurId;
     private String message;
 }

--- a/backend_forum/src/main/java/fr/dsfr/forum/controllers/SujetController.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/controllers/SujetController.java
@@ -47,7 +47,7 @@ public class SujetController {
         Message message = new Message();
         message.setContenu(dto.getMessage());
         message.setDateCreation(LocalDateTime.now());
-        message.setAuteur(validator.getAuteurOrThrow(Long.parseLong(dto.getAuteurId())));
+        message.setAuteur(validator.getAuteurOrThrow(dto.getAuteurId()));
         message.setSujet(sujet);
 
         sujet.getMessages().add(message);


### PR DESCRIPTION
## Summary
- use `Long auteurId` in `CreerSujetDTO`
- remove `Long.parseLong` usage in `SujetController`
------
https://chatgpt.com/codex/tasks/task_e_6845abf1d28483219b64ea95a76dc411