### PR TITLE
Fix typo in forum error message

### DIFF
--- a/frontend/src/components/Forum/ForumList.vue
+++ b/frontend/src/components/Forum/ForumList.vue
@@ -4,7 +4,7 @@
     
     <!-- Chargement des forums -->
     <ChargementSpinner v-if="enChargement"/>
-    <ErreurMessage v-if="erreurChargement" message="Une erreur est sruvenue lors du chargement des forums."/>
+    <ErreurMessage v-if="erreurChargement" message="Une erreur est survenue lors du chargement des forums."/>
     
     <div class="fr-grid-row fr-grid-row--gutters fr-mt-5w">
       <div


### PR DESCRIPTION
## Summary
- fix typo in ForumList component error message

------
https://chatgpt.com/codex/tasks/task_e_6845b08bc77483219ed21f6eaa373e7b