### PR TITLE
Ajout de l'authentification Keycloak

### DIFF
--- a/backend_forum/pom.xml
+++ b/backend_forum/pom.xml
@@ -110,6 +110,13 @@
             <version>3.5.0</version>
         </dependency>
 
+        <!-- Client d'administration Keycloak -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+            <version>26.0.5</version>
+        </dependency>
+
 
     </dependencies>
 

--- a/backend_forum/src/main/java/fr/dsfr/forum/beans/dto/AuthDTO/LoginRequestDTO.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/beans/dto/AuthDTO/LoginRequestDTO.java
@@ -1,0 +1,9 @@
+package fr.dsfr.forum.beans.dto.AuthDTO;
+
+import lombok.Data;
+
+@Data
+public class LoginRequestDTO {
+    private String username;
+    private String password;
+}

--- a/backend_forum/src/main/java/fr/dsfr/forum/beans/dto/AuthDTO/LoginResponseDTO.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/beans/dto/AuthDTO/LoginResponseDTO.java
@@ -1,0 +1,12 @@
+package fr.dsfr.forum.beans.dto.AuthDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginResponseDTO {
+    private String accessToken;
+    private String refreshToken;
+    private String idToken;
+}

--- a/backend_forum/src/main/java/fr/dsfr/forum/beans/dto/AuthDTO/RegisterUserDTO.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/beans/dto/AuthDTO/RegisterUserDTO.java
@@ -1,0 +1,10 @@
+package fr.dsfr.forum.beans.dto.AuthDTO;
+
+import lombok.Data;
+
+@Data
+public class RegisterUserDTO {
+    private String username;
+    private String email;
+    private String password;
+}

--- a/backend_forum/src/main/java/fr/dsfr/forum/configurations/SecurityConfig.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/configurations/SecurityConfig.java
@@ -36,8 +36,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // Autorise toutes les requêtes sans restriction
+                // Configuration des autorisations
                 .authorizeHttpRequests(authz -> authz
+                        .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(oauth2 -> oauth2

--- a/backend_forum/src/main/java/fr/dsfr/forum/controllers/AuthController.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/controllers/AuthController.java
@@ -1,6 +1,8 @@
 package fr.dsfr.forum.controllers;
 
 import fr.dsfr.forum.beans.dto.AuthDTO.RegisterUserDTO;
+import fr.dsfr.forum.beans.dto.AuthDTO.LoginRequestDTO;
+import fr.dsfr.forum.beans.dto.AuthDTO.LoginResponseDTO;
 import fr.dsfr.forum.services.auth.KeycloakAdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,5 +20,12 @@ public class AuthController {
     public ResponseEntity<Void> register(@RequestBody RegisterUserDTO dto) {
         keycloakAdminService.createUser(dto.getUsername(), dto.getEmail(), dto.getPassword());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDTO> login(@RequestBody LoginRequestDTO dto) {
+        var token = keycloakAdminService.login(dto.getUsername(), dto.getPassword());
+        LoginResponseDTO response = new LoginResponseDTO(token.getToken(), token.getRefreshToken(), token.getIdToken());
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend_forum/src/main/java/fr/dsfr/forum/controllers/AuthController.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/controllers/AuthController.java
@@ -1,0 +1,22 @@
+package fr.dsfr.forum.controllers;
+
+import fr.dsfr.forum.beans.dto.AuthDTO.RegisterUserDTO;
+import fr.dsfr.forum.services.auth.KeycloakAdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final KeycloakAdminService keycloakAdminService;
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> register(@RequestBody RegisterUserDTO dto) {
+        keycloakAdminService.createUser(dto.getUsername(), dto.getEmail(), dto.getPassword());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/backend_forum/src/main/java/fr/dsfr/forum/services/auth/KeycloakAdminService.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/services/auth/KeycloakAdminService.java
@@ -7,10 +7,13 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 import java.util.Collections;
 
@@ -29,6 +32,9 @@ public class KeycloakAdminService {
 
     @Value("${keycloak.admin.password}")
     private String password;
+
+    @Value("${keycloak.client-id}")
+    private String clientId;
 
     private Keycloak keycloak;
 
@@ -60,5 +66,17 @@ public class KeycloakAdminService {
         user.setCredentials(Collections.singletonList(credentials));
 
         usersResource.create(user);
+    }
+
+    public AccessTokenResponse login(String user, String pass) {
+        Keycloak kc = KeycloakBuilder.builder()
+                .serverUrl(serverUrl)
+                .realm(realm)
+                .grantType(OAuth2Constants.PASSWORD)
+                .clientId(clientId)
+                .username(user)
+                .password(pass)
+                .build();
+        return kc.tokenManager().getAccessToken();
     }
 }

--- a/backend_forum/src/main/java/fr/dsfr/forum/services/auth/KeycloakAdminService.java
+++ b/backend_forum/src/main/java/fr/dsfr/forum/services/auth/KeycloakAdminService.java
@@ -1,0 +1,64 @@
+package fr.dsfr.forum.services.auth;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class KeycloakAdminService {
+
+    @Value("${keycloak.admin.url}")
+    private String serverUrl;
+
+    @Value("${keycloak.admin.realm}")
+    private String realm;
+
+    @Value("${keycloak.admin.username}")
+    private String username;
+
+    @Value("${keycloak.admin.password}")
+    private String password;
+
+    private Keycloak keycloak;
+
+    @PostConstruct
+    public void init() {
+        keycloak = KeycloakBuilder.builder()
+                .serverUrl(serverUrl)
+                .realm(realm)
+                .grantType(OAuth2Constants.PASSWORD)
+                .clientId("admin-cli")
+                .username(username)
+                .password(password)
+                .build();
+    }
+
+    public void createUser(String login, String email, String rawPassword) {
+        RealmResource realmResource = keycloak.realm(realm);
+        UsersResource usersResource = realmResource.users();
+
+        CredentialRepresentation credentials = new CredentialRepresentation();
+        credentials.setType(CredentialRepresentation.PASSWORD);
+        credentials.setValue(rawPassword);
+        credentials.setTemporary(false);
+
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(login);
+        user.setEmail(email);
+        user.setEnabled(true);
+        user.setCredentials(Collections.singletonList(credentials));
+
+        usersResource.create(user);
+    }
+}

--- a/backend_forum/src/main/resources/application.properties
+++ b/backend_forum/src/main/resources/application.properties
@@ -10,3 +10,9 @@ spring.flyway.locations=classpath:db/migration
 # --- Keycloak OAuth2 Resource Server ---
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8083/realms/forum-dsfr
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8083/realms/forum-dsfr/protocol/openid-connect/certs
+
+# --- Configuration pour l'administration Keycloak ---
+keycloak.admin.url=http://localhost:8083
+keycloak.admin.realm=master
+keycloak.admin.username=admin
+keycloak.admin.password=admin

--- a/backend_forum/src/main/resources/application.properties
+++ b/backend_forum/src/main/resources/application.properties
@@ -16,3 +16,4 @@ keycloak.admin.url=http://localhost:8083
 keycloak.admin.realm=master
 keycloak.admin.username=admin
 keycloak.admin.password=admin
+keycloak.client-id=frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "focus-trap": "^7.6.4",
     "focus-trap-vue": "^4.0.3",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "keycloak-js": "^26.2.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.12.1",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router/index'
+import keycloak, { initKeycloak } from './services/keycloak'
 import '@gouvfr/dsfr/dist/core/core.main.min.css'
 
 import '@gouvfr/dsfr/dist/component/component.main.min.css'
@@ -13,6 +14,8 @@ import '@gouvfr/dsfr/dist/utility/icons/icons.min.css'
 
 import './main.css'
 
-createApp(App)
-  .use(router)
-  .mount('#app')
+initKeycloak().then(() => {
+  createApp(App)
+    .use(router)
+    .mount('#app')
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,6 +2,8 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 import AboutUs from '../views/AboutUs.vue'
 import Home from '../views/AppHome.vue'
+import Login from '../views/Login.vue'
+import Register from '../views/Register.vue'
 import ForumList from "@/components/Forum/ForumList.vue";
 import SujetList from "@/components/Sujet/SujetList.vue";
 import Sujet from "@/components/Sujet/Sujet.vue";
@@ -18,6 +20,16 @@ const routes = [
     path: '/a-propos',
     name: 'About',
     component: AboutUs,
+  },
+  {
+    path: '/connexion',
+    name: 'Login',
+    component: Login,
+  },
+  {
+    path: '/enregistrement',
+    name: 'Register',
+    component: Register,
   },
   {
     path: '/forums',

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -94,6 +94,16 @@ export async function registerUser(dto: { username: string; email: string; passw
   if (!response.ok) throw new Error('Erreur lors de l\'enregistrement')
 }
 
+export async function loginUser(dto: { username: string; password: string }): Promise<{ accessToken: string; refreshToken: string; idToken: string }> {
+  const response = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(dto)
+  })
+  if (!response.ok) throw new Error('Erreur lors de la connexion')
+  return await response.json()
+}
+
 function authHeaders(): Record<string, string> {
   if (keycloak.token) {
     return { Authorization: 'Bearer ' + keycloak.token }

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -1,7 +1,8 @@
 // src/services/apiService.ts
 import type { Forum } from '@/models/Forum'
-import type {Sujet} from "@/models/Sujet";
-import type {Message} from "@/models/Message";
+import type { Sujet } from '@/models/Sujet'
+import type { Message } from '@/models/Message'
+import keycloak from './keycloak'
 
 /**
  * Récupère la liste de tous les forums depuis l'API backend.
@@ -10,7 +11,9 @@ import type {Message} from "@/models/Message";
  */
 export async function getAllForums(): Promise<Forum[]> {
   console.log('Appel API /api/forums...')
-  const response = await fetch('/api/forums')
+  const response = await fetch('/api/forums', {
+    headers: authHeaders()
+  })
   if (!response.ok) throw new Error('Erreur lors du chargement des forums')
   return await response.json()
 }
@@ -23,7 +26,9 @@ export async function getAllForums(): Promise<Forum[]> {
  */
 export async function getSujetsByForumId(forumId: number): Promise<Forum> {
   console.log('Appel API /api/forums/id='+ forumId)
-  const response = await fetch('/api/forums/'+ forumId)
+  const response = await fetch('/api/forums/'+ forumId, {
+    headers: authHeaders()
+  })
   if (!response.ok) throw new Error('Erreur lors du chargement des sujets')
   return await response.json()
 }
@@ -40,7 +45,7 @@ export async function creerSujet(forumId: number, dto: {
 }): Promise<Sujet> {
   const response = await fetch('/api/forums/'+forumId+'/sujets/create', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(dto)
   })
   if (!response.ok) throw new Error('Erreur lors de la création du sujet')
@@ -54,7 +59,9 @@ export async function creerSujet(forumId: number, dto: {
  */
 export async function getMessagesBySujetId(forumId: number, sujetId: number): Promise<Message[]> {
   console.log('Appel API /api/forums/'+ forumId +'/sujets/'+ sujetId + '/messages')
-  const response = await fetch('/api/forums/'+ forumId +'/sujets/'+ sujetId + '/messages')
+  const response = await fetch('/api/forums/'+ forumId +'/sujets/'+ sujetId + '/messages', {
+    headers: authHeaders()
+  })
   if (!response.ok) throw new Error('Erreur lors du chargement des messages')
   return await response.json()
 }
@@ -71,10 +78,26 @@ export async function creerMessage(forumId: number, sujetId: number, dto: {
 }): Promise<Message> {
   const response = await fetch('/api/forums/'+ forumId +'/sujets/'+ sujetId + '/messages/create', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(dto)
   })
   if (!response.ok) throw new Error('Erreur lors de la création du message')
   return await response.json()
+}
+
+export async function registerUser(dto: { username: string; email: string; password: string }): Promise<void> {
+  const response = await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(dto)
+  })
+  if (!response.ok) throw new Error('Erreur lors de l\'enregistrement')
+}
+
+function authHeaders(): Record<string, string> {
+  if (keycloak.token) {
+    return { Authorization: 'Bearer ' + keycloak.token }
+  }
+  return {}
 }
 

--- a/frontend/src/services/keycloak.ts
+++ b/frontend/src/services/keycloak.ts
@@ -1,4 +1,4 @@
-import Keycloak from 'keycloak-js'
+import Keycloak, { type KeycloakInitOptions } from 'keycloak-js'
 
 const keycloak = new Keycloak({
   url: 'http://localhost:8083',
@@ -6,8 +6,8 @@ const keycloak = new Keycloak({
   clientId: 'frontend'
 })
 
-export function initKeycloak() {
-  return keycloak.init({ onLoad: 'check-sso', pkceMethod: 'S256' })
+export function initKeycloak(options: KeycloakInitOptions = {}) {
+  return keycloak.init({ onLoad: 'check-sso', pkceMethod: 'S256', ...options })
 }
 
 export default keycloak

--- a/frontend/src/services/keycloak.ts
+++ b/frontend/src/services/keycloak.ts
@@ -1,0 +1,13 @@
+import Keycloak from 'keycloak-js'
+
+const keycloak = new Keycloak({
+  url: 'http://localhost:8083',
+  realm: 'forum-dsfr',
+  clientId: 'frontend'
+})
+
+export function initKeycloak() {
+  return keycloak.init({ onLoad: 'check-sso', pkceMethod: 'S256' })
+}
+
+export default keycloak

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,15 +1,28 @@
 <template>
   <section class="fr-container fr-mt-6w">
     <h1 class="fr-h2">Connexion</h1>
-    <DsfrButton @click="login">Se connecter avec Keycloak</DsfrButton>
+    <form @submit.prevent="submit">
+      <DsfrInput v-model="username" label="Identifiant" required />
+      <DsfrInput v-model="password" label="Mot de passe" type="password" required />
+      <DsfrButton type="submit">Se connecter</DsfrButton>
+    </form>
   </section>
 </template>
 
 <script setup lang="ts">
-import { DsfrButton } from '@gouvminint/vue-dsfr'
-import keycloak from '@/services/keycloak'
+import { ref } from 'vue'
+import { DsfrInput, DsfrButton } from '@gouvminint/vue-dsfr'
+import { loginUser } from '@/services/apiService'
+import { initKeycloak } from '@/services/keycloak'
+import { useRouter } from 'vue-router'
 
-function login() {
-  keycloak.login({ redirectUri: window.location.origin })
+const username = ref('')
+const password = ref('')
+const router = useRouter()
+
+async function submit() {
+  const tokens = await loginUser({ username: username.value, password: password.value })
+  await initKeycloak({ token: tokens.accessToken, refreshToken: tokens.refreshToken, idToken: tokens.idToken })
+  router.push('/')
 }
 </script>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,0 +1,15 @@
+<template>
+  <section class="fr-container fr-mt-6w">
+    <h1 class="fr-h2">Connexion</h1>
+    <DsfrButton @click="login">Se connecter avec Keycloak</DsfrButton>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { DsfrButton } from '@gouvminint/vue-dsfr'
+import keycloak from '@/services/keycloak'
+
+function login() {
+  keycloak.login({ redirectUri: window.location.origin })
+}
+</script>

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -1,0 +1,25 @@
+<template>
+  <section class="fr-container fr-mt-6w">
+    <h1 class="fr-h2">Créer un compte</h1>
+    <form @submit.prevent="register">
+      <DsfrInput v-model="username" label="Nom d'utilisateur" required />
+      <DsfrInput v-model="email" label="Email" type="email" required />
+      <DsfrInput v-model="password" label="Mot de passe" type="password" required />
+      <DsfrButton type="submit">S'enregistrer</DsfrButton>
+    </form>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { DsfrInput, DsfrButton } from '@gouvminint/vue-dsfr'
+import { registerUser } from '@/services/apiService'
+
+const username = ref('')
+const email = ref('')
+const password = ref('')
+
+async function register() {
+  await registerUser({ username: username.value, email: email.value, password: password.value })
+}
+</script>


### PR DESCRIPTION
## Résumé
- intégration du client d'administration Keycloak côté backend
- ajout d'un contrôleur d'enregistrement et configuration de sécurité
- initialisation de Keycloak dans l'application Vue
- nouvelles pages `Login` et `Register` suivant le DSFR
- en-tête d'autorisation ajouté aux appels API

## Tests
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_6845d0d4f4c48321bab6baffa12d6ec8