### PR TITLE
Fix login flow with Keycloak

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { useScheme } from '@gouvminint/vue-dsfr'
 import useToaster from './composables/use-toaster'
+import { computed, onMounted, ref } from 'vue'
+import keycloak, { logoutKeycloak } from './services/keycloak'
+import router from './router'
 
 useScheme()
 
@@ -10,36 +13,56 @@ const serviceTitle = 'Service'
 const serviceDescription = 'Description du service'
 const logoText = ['Ministère', 'de l’intérieur']
 
-const quickLinks = [
-  {
-    label: 'Home',
-    to: '/',
-    icon: 'ri-home-4-line',
-    iconAttrs: { color: 'var(--red-marianne-425-625)' },
-  },
-  {
-    label: 'Forums',
-    to: '/forums',
-    icon: 'fr-icon-team-fill',
-  },
-  {
-    label: "Connexion",
-    to: '/connexion',
-    icon: 'fr-icon-user-fill',
-  },
-  {
-    label: "Inscription",
-    to: '/inscription',
-    icon: 'fr-icon-user-add-fill',
-  },
-  {
-    label: 'À propos',
-    to: '/a-propos',
-    icon: 'ri-question-mark',
-    iconLeft: true,
-  }
-]
 const searchQuery = ref('')
+
+const isAuthenticated = ref(false)
+const username = ref('')
+
+onMounted(() => {
+  if (keycloak.authenticated) {
+    isAuthenticated.value = true
+    username.value = keycloak.tokenParsed?.preferred_username ?? ''
+  }
+  keycloak.onAuthSuccess = () => {
+    isAuthenticated.value = true
+    username.value = keycloak.tokenParsed?.preferred_username ?? ''
+  }
+  keycloak.onAuthLogout = () => {
+    isAuthenticated.value = false
+    username.value = ''
+  }
+})
+
+function deconnecter() {
+  logoutKeycloak().then(() => {
+    router.push('/connexion')
+  })
+}
+
+const quickLinks = computed(() => {
+  const links = [
+    {
+      label: 'Home',
+      to: '/',
+      icon: 'ri-home-4-line',
+      iconAttrs: { color: 'var(--red-marianne-425-625)' },
+    },
+    {
+      label: 'Forums',
+      to: '/',
+      icon: 'fr-icon-team-fill',
+    },
+  ]
+  if (isAuthenticated.value) {
+    links.push({ label: username.value, icon: 'fr-icon-user-fill' })
+    links.push({ label: 'Déconnexion', onClick: deconnecter, icon: 'ri-logout-box-r-line' })
+  } else {
+    links.push({ label: 'Connexion', to: '/connexion', icon: 'fr-icon-user-fill' })
+    links.push({ label: 'Inscription', to: '/inscription', icon: 'fr-icon-user-add-fill' })
+  }
+  links.push({ label: 'À propos', to: '/a-propos', icon: 'ri-question-mark', iconLeft: true })
+  return links
+})
 </script>
 
 <template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router/index'
-import keycloak, { initKeycloak } from './services/keycloak'
+import { initKeycloak } from './services/keycloak'
 import '@gouvfr/dsfr/dist/core/core.main.min.css'
 
 import '@gouvfr/dsfr/dist/component/component.main.min.css'
@@ -14,20 +14,13 @@ import '@gouvfr/dsfr/dist/utility/icons/icons.min.css'
 
 import './main.css'
 
-initKeycloak({ onLoad: 'check-sso', pkceMethod: 'S256' })
-  .then((authenticated) => {
-    if (authenticated) {
-      console.log("Token Keycloak :", keycloak.token)
-      console.log("Token d'actualisation Keycloak :", keycloak.refreshToken)
-      console.log("Utilisateur Keycloak :", keycloak.tokenParsed)
-    } else {
-      console.warn("Utilisateur non authentifié")
-    }
-
+initKeycloak()
+  .then(() => {
     createApp(App)
       .use(router)
       .mount('#app')
   })
   .catch((err) => {
-    console.error('Erreur lors de l\'initialisation de Keycloak :', err)
+    console.error("Erreur lors de l'initialisation de Keycloak :", err)
   })
+

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,10 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
 import AboutUs from '../views/AboutUs.vue'
-import Home from '../views/AppHome.vue'
 import ConnexionUtilisateur from '../views/ConnexionUtilisateur.vue'
 import InscriptionUtilisateur from '../views/InscriptionUtilisateur.vue'
-import ForumList from "@/components/Forum/ForumList.vue";
+import ForumList from '@/components/Forum/ForumList.vue'
 import SujetList from "@/components/Sujet/SujetList.vue";
 import Sujet from "@/components/Sujet/Sujet.vue";
 
@@ -14,7 +13,7 @@ const routes = [
   {
     path: '/',
     name: 'Home',
-    component: Home,
+    component: ForumList,
   },
   {
     path: '/a-propos',
@@ -33,8 +32,7 @@ const routes = [
   },
   {
     path: '/forums',
-    name: 'Forums',
-    component: ForumList,
+    redirect: '/',
   },
   { path: '/forums/:forumId/sujets', 
     name: 'Sujets', 

--- a/frontend/src/services/keycloak.ts
+++ b/frontend/src/services/keycloak.ts
@@ -6,13 +6,68 @@ const keycloak = new Keycloak({
   clientId: 'forum-dsfr-frontend'
 })
 
-export function initKeycloak(options: KeycloakInitOptions = {}) {
-  // Vérifie si l'utilisateur est déjà authentifié
-  if (keycloak.authenticated) {
-    console.log('Utilisateur déjà authentifié')
-    return Promise.resolve(true)
+const TOKEN_KEY = 'kc_token'
+const REFRESH_KEY = 'kc_refresh'
+const ID_KEY = 'kc_id'
+
+let initialized = false
+
+function saveTokens() {
+  if (keycloak.token) {
+    sessionStorage.setItem(TOKEN_KEY, keycloak.token)
+    if (keycloak.refreshToken) {
+      sessionStorage.setItem(REFRESH_KEY, keycloak.refreshToken)
+    }
+    if (keycloak.idToken) {
+      sessionStorage.setItem(ID_KEY, keycloak.idToken)
+    }
   }
-  return keycloak.init({ onLoad: 'check-sso', pkceMethod: 'S256', ...options })
+}
+
+function clearTokens() {
+  sessionStorage.removeItem(TOKEN_KEY)
+  sessionStorage.removeItem(REFRESH_KEY)
+  sessionStorage.removeItem(ID_KEY)
+}
+
+export async function initKeycloak(options: KeycloakInitOptions = {}) {
+  if (initialized) {
+    if (options.token) {
+      keycloak.token = options.token as string
+      keycloak.refreshToken = options.refreshToken
+      keycloak.idToken = options.idToken
+      saveTokens()
+      return true
+    }
+    return keycloak.authenticated ?? false
+  }
+
+  const storedToken = sessionStorage.getItem(TOKEN_KEY) || undefined
+  const storedRefresh = sessionStorage.getItem(REFRESH_KEY) || undefined
+  const storedId = sessionStorage.getItem(ID_KEY) || undefined
+
+  const opts: KeycloakInitOptions = {
+    onLoad: 'check-sso',
+    pkceMethod: 'S256',
+    ...options,
+    token: options.token ?? storedToken,
+    refreshToken: options.refreshToken ?? storedRefresh,
+    idToken: options.idToken ?? storedId
+  }
+
+  const authenticated = await keycloak.init(opts)
+  initialized = true
+  if (authenticated) {
+    saveTokens()
+  } else {
+    clearTokens()
+  }
+  return authenticated
+}
+
+export async function logoutKeycloak() {
+  clearTokens()
+  await keycloak.logout()
 }
 
 export default keycloak

--- a/frontend/src/views/ConnexionUtilisateur.vue
+++ b/frontend/src/views/ConnexionUtilisateur.vue
@@ -1,5 +1,12 @@
 <template>
   <DsfrBreadcrumb :links="filAriane" />
+  <DsfrNotice
+    v-if="messageSucces"
+    type="success"
+    title="Inscription réussie"
+    :description="messageSucces"
+    class="fr-mb-3v"
+  />
   <main class="fr-pt-md-14v" role="main" id="content">
     <div class="fr-container fr-container--fluid fr-mb-md-14v">
       <div class="fr-grid-row fr-grid-row-gutters fr-grid-row--center">
@@ -52,11 +59,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import {DsfrButton, DsfrBreadcrumb} from '@gouvminint/vue-dsfr'
+import { onMounted, ref } from 'vue'
+import {DsfrButton, DsfrBreadcrumb, DsfrNotice} from '@gouvminint/vue-dsfr'
 import { connecterUtilisateur } from '@/services/apiService'
 import { initKeycloak } from '@/services/keycloak'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 
 const filAriane = [
   { to: '/', text: 'Accueil' },
@@ -66,6 +73,15 @@ const pseudonyme = ref('')
 const motDePasse = ref('')
 const seSouvenir = ref(false)
 const router = useRouter()
+const route = useRoute()
+const messageSucces = ref('')
+
+onMounted(() => {
+  if (route.query.registered) {
+    messageSucces.value = 'Votre compte a été créé. Vous pouvez maintenant vous connecter.'
+    router.replace({ query: {} })
+  }
+})
 
 function creerCompte() {
   router.push('/inscription')

--- a/frontend/src/views/InscriptionUtilisateur.vue
+++ b/frontend/src/views/InscriptionUtilisateur.vue
@@ -74,12 +74,6 @@
       </div>
     </form>
 
-    <DsfrNotice
-      v-if="isFormulaireSoumis"
-      title="Inscription réussie"
-      description="Votre compte a bien été créé."
-      class="fr-mt-4v"
-    />
   </div>
 </template>
 
@@ -96,6 +90,7 @@ import {
 } from '@gouvminint/vue-dsfr'
 import useInscriptionValidation from '@/composables/use-inscription-validation'
 import { inscrireUtilisateur } from '@/services/apiService'
+import { useRouter } from 'vue-router'
 
 const filAriane = [
   { to: '/', text: 'Accueil' },
@@ -124,8 +119,8 @@ const {
 
 // Erreur globale (submit)
 const erreurGlobal = ref<{titre:string,texte:string}|null>(null)
-const isFormulaireSoumis = ref(false)
 const etapeCourante = ref(1)
+const router = useRouter()
 
 // Navigation étapes
 function etapeSuivante() {
@@ -160,7 +155,7 @@ async function soumettreFormulaire() {
       email: form.email,
       motDePasse: form.password
     })
-    isFormulaireSoumis.value = true
+    await router.push({ path: '/connexion', query: { registered: '1' } })
   } catch (e: any) {
     erreurGlobal.value = { titre: 'Erreur serveur', texte: e.message || 'Réessayez plus tard.' }
   }


### PR DESCRIPTION
## Summary
- configure Keycloak service as singleton with sessionStorage token persistance
- manage user connexion and inscription flows
- show the logged in user with a logout action in the header
- redirect registration to connexion with notice
- display forums list as home page

------
https://chatgpt.com/codex/tasks/task_e_68474206741c832188b2cd14deb7dacb